### PR TITLE
Cleanup

### DIFF
--- a/DevTale/MainForm.h
+++ b/DevTale/MainForm.h
@@ -19,6 +19,9 @@
 
 #include <msclr/marshal_cppstd.h>
 
+#pragma warning(push)
+#pragma warning(disable: 4100) //unused formal parameter warning
+
 // Disclaimer:
 // 
 // This file may (and surely will) look bad, but changes to it
@@ -47,9 +50,6 @@ namespace devtale
 		MainForm(void)
 		{
 			InitializeComponent();
-			//
-			//TODO: Add the constructor code here
-			//
 		}
 
 	protected:
@@ -74,156 +74,65 @@ namespace devtale
 			}
 		}
 
-	private:
-		System::Windows::Forms::TabControl^ tabControl1;
-	private:
-		System::Windows::Forms::TabPage^ tabPage1;
-	private:
-		System::Windows::Forms::GroupBox^ groupBox1;
-	private:
-		System::Windows::Forms::TabPage^ tabPage2;
-	private:
-		System::Windows::Forms::GroupBox^ groupBox2;
-	public:
-		System::Windows::Forms::TextBox^ packetLogTextBox;
-	public: System::Windows::Forms::CheckBox^ logSentPacketsCheckBox;
-	public: System::Windows::Forms::CheckBox^ logReceivedPacketsCheckBox;
-	public:
+	private : 
+        System::Windows::Forms::TabControl^ tabControl1;
+        System::Windows::Forms::TabPage^ tabPage1;
+        System::Windows::Forms::GroupBox^ groupBox1;
+        System::Windows::Forms::TabPage^ tabPage2;
+        System::Windows::Forms::GroupBox^ groupBox2;
+        System::Windows::Forms::Label^ label1;
+        System::Windows::Forms::TabControl^ tabControl2;
+        System::Windows::Forms::TabPage^ tabPage3;
+        System::Windows::Forms::TabPage^ tabPage4;
+        System::Windows::Forms::GroupBox^ groupBox4;
+        System::Windows::Forms::NumericUpDown^ sendPacketIntervalTextBox;
+        System::Windows::Forms::NumericUpDown^ sendPacketCountTextBox;
+        System::Windows::Forms::RadioButton^ sendPacketIntervalRadio;
+        System::Windows::Forms::RadioButton^ sendPacketCountRadio;
+        System::Windows::Forms::Button^ multiplePacketSendButton;
+        System::Windows::Forms::TextBox^ multiplePacketSendTextBox;
+        System::Windows::Forms::GroupBox^ groupBox3;
+        System::Windows::Forms::Button^ singlePacketSendButton;
+        System::Windows::Forms::TextBox^ singlePacketSendTextBox;
+        System::Windows::Forms::GroupBox^ groupBox5;
+        System::Windows::Forms::NumericUpDown^ receivePacketIntervalTextBox;
+        System::Windows::Forms::NumericUpDown^ receivePacketCountTextBox;
+        System::Windows::Forms::RadioButton^ receivePacketIntervalRadio;
+        System::Windows::Forms::RadioButton^ receivePacketCountRadio;
+        System::Windows::Forms::TextBox^ multiplePacketReceiveTextBox;
+        System::Windows::Forms::Button^ multiplePacketReceiveButton;
+        System::Windows::Forms::GroupBox^ groupBox6;
+        System::Windows::Forms::Button^ singlePacketReceiveButton;
+        System::Windows::Forms::TextBox^ singlePacketReceiveTextBox;
+        System::Windows::Forms::TabPage^ tabPage5;
+        System::Windows::Forms::GroupBox^ groupBox8;
+        System::Windows::Forms::Button^ newReceivedPacketFilterButton;
+        System::Windows::Forms::Button^ removeReceivedPacketFilterButton;
+        System::Windows::Forms::TextBox^ newReceivedPacketFilterTextBox;
+        System::Windows::Forms::GroupBox^ groupBox7;
+        System::Windows::Forms::Button^ newSentPacketFilterButton;
+        System::Windows::Forms::TextBox^ newSentPacketFilterTextBox;
+        System::Windows::Forms::Button^ removeSentPacketFilterButton;
+        System::Windows::Forms::Timer^ sendTimer;
+        System::Windows::Forms::Timer^ receiveTimer;
+        System::Windows::Forms::GroupBox^ groupBox9;
+        System::Windows::Forms::PictureBox^ pictureBox1;
+        System::ComponentModel::IContainer^ components;
 
-	public:
-		System::Windows::Forms::CheckBox^ enableReceivedPacketFilterCheckBox;
-		System::Windows::Forms::CheckBox^ enableSentPacketFilterCheckBox;
-	private:
-		System::Windows::Forms::Label^ label1;
-	private:
-		System::Windows::Forms::TabControl^ tabControl2;
-	private:
-		System::Windows::Forms::TabPage^ tabPage3;
-	private:
-		System::Windows::Forms::TabPage^ tabPage4;
-	private:
-		System::Windows::Forms::GroupBox^ groupBox4;
-	private: System::Windows::Forms::NumericUpDown^ sendPacketIntervalTextBox;
-
-	private:
-
-	private: System::Windows::Forms::NumericUpDown^ sendPacketCountTextBox;
-	private: System::Windows::Forms::RadioButton^ sendPacketIntervalRadio;
-	private:
-
-
-	private:
-
-	private: System::Windows::Forms::RadioButton^ sendPacketCountRadio;
-
-
-	private:
-
-	private:
-		System::Windows::Forms::Button^ multiplePacketSendButton;
-	private: System::Windows::Forms::TextBox^ multiplePacketSendTextBox;
-
-	private:
-
-	private:
-		System::Windows::Forms::GroupBox^ groupBox3;
-	private:
-		System::Windows::Forms::Button^ singlePacketSendButton;
-	private: System::Windows::Forms::TextBox^ singlePacketSendTextBox;
-	private:
-
-	private:
-		System::Windows::Forms::GroupBox^ groupBox5;
-	private: System::Windows::Forms::NumericUpDown^ receivePacketIntervalTextBox;
-	private:
-
-	private: System::Windows::Forms::NumericUpDown^ receivePacketCountTextBox;
-	private:
-
-	private: System::Windows::Forms::RadioButton^ receivePacketIntervalRadio;
-	private:
-
-	private: System::Windows::Forms::RadioButton^ receivePacketCountRadio;
-
-	private:
-
-	private: System::Windows::Forms::TextBox^ multiplePacketReceiveTextBox;
-	private:
-
-	private:
-		System::Windows::Forms::Button^ multiplePacketReceiveButton;
-
-
-	private:
-		System::Windows::Forms::GroupBox^ groupBox6;
-	private:
-		System::Windows::Forms::Button^ singlePacketReceiveButton;
-private: System::Windows::Forms::TextBox^ singlePacketReceiveTextBox;
-
-	private:
-
-
-
-	private:
-		System::Windows::Forms::TabPage^ tabPage5;
-	private:
-		System::Windows::Forms::GroupBox^ groupBox8;
-	private:
-		System::Windows::Forms::Button^ newReceivedPacketFilterButton;
-private: System::Windows::Forms::Button^ removeReceivedPacketFilterButton;
-private: System::Windows::Forms::TextBox^ newReceivedPacketFilterTextBox;
-	private:
-
-	private:
-
-public: System::Windows::Forms::ListBox^ filterReceivedPacketList;
-	private:
-
-	private:
-		System::Windows::Forms::GroupBox^ groupBox7;
-	private:
-		System::Windows::Forms::Button^ newSentPacketFilterButton;
-private: System::Windows::Forms::TextBox^ newSentPacketFilterTextBox;
-	private:
-
-private: System::Windows::Forms::Button^ removeSentPacketFilterButton;
-	private:
-
-public: System::Windows::Forms::ListBox^ filterSentPacketList;
-	private:
-
-	private:
-
-	private:
-
-	private:
-
-
-private: System::Windows::Forms::Timer^ sendTimer;
-private: System::Windows::Forms::Timer^ receiveTimer;
-public: System::Windows::Forms::RadioButton^ receivedWhitelistRadio;
-public: System::Windows::Forms::RadioButton^ receivedBlacklistRadio;
-public: System::Windows::Forms::RadioButton^ sentWhitelistRadio;
-public: System::Windows::Forms::RadioButton^ sentBlacklistRadio;
-private: System::Windows::Forms::GroupBox^ groupBox9;
-public: System::Windows::Forms::CheckBox^ packetLogPrependTimeCheckBox;
-private:
-
-public: System::Windows::Forms::CheckBox^ packetLogPrependDirectionCheckBox;
-private: System::Windows::Forms::PictureBox^ pictureBox1;
-public:
-
-public:
-public:
-
-
-	private: System::ComponentModel::IContainer^ components;
-
-
-	private:
-		/// <summary>
-		/// Required designer variable.
-		/// </summary>
+    public:
+        System::Windows::Forms::RadioButton^ receivedWhitelistRadio;
+        System::Windows::Forms::RadioButton^ receivedBlacklistRadio;
+        System::Windows::Forms::RadioButton^ sentWhitelistRadio;
+        System::Windows::Forms::RadioButton^ sentBlacklistRadio;
+        System::Windows::Forms::CheckBox^ packetLogPrependDirectionCheckBox;
+        System::Windows::Forms::CheckBox^ packetLogPrependTimeCheckBox;
+        System::Windows::Forms::ListBox^ filterReceivedPacketList;
+        System::Windows::Forms::TextBox^ packetLogTextBox;
+        System::Windows::Forms::ListBox^ filterSentPacketList;
+        System::Windows::Forms::CheckBox^ logSentPacketsCheckBox;
+        System::Windows::Forms::CheckBox^ logReceivedPacketsCheckBox;
+        System::Windows::Forms::CheckBox^ enableReceivedPacketFilterCheckBox;
+        System::Windows::Forms::CheckBox^ enableSentPacketFilterCheckBox;
 
 
 #pragma region Windows Form Designer generated code
@@ -231,6 +140,7 @@ public:
 		/// Required method for Designer support - do not modify
 		/// the contents of this method with the code editor.
 		/// </summary>
+    private:
 		void InitializeComponent(void)
 		{
 			this->components = (gcnew System::ComponentModel::Container());
@@ -937,115 +847,156 @@ public:
 
 		}
 #pragma endregion
-	private: System::Void SinglePacketSendButton_Click(System::Object^ sender, System::EventArgs^ e) {
-		devtale::Protocol::get()->send(marshal_as<std::string>(singlePacketSendTextBox->Text));
-	}
-	private: System::Void SinglePacketReceiveButton_Click(System::Object^ sender, System::EventArgs^ e) {
-		try {
-		devtale::Protocol::get()->receive(marshal_as<std::string>(singlePacketReceiveTextBox->Text));
-		}
-		catch (Runtime::InteropServices::SEHException^)
+
+
+	private:
+		System::Void SinglePacketSendButton_Click(System::Object^ sender, System::EventArgs^ e) 
 		{
-			// ignore Access Violations
+			devtale::Protocol::get()->send(marshal_as<std::string>(singlePacketSendTextBox->Text));
 		}
-	}
-private: System::Void MultiplePacketSendButton_Click(System::Object^ sender, System::EventArgs^ e) {
-	if (sendPacketCountRadio->Checked) {
-		auto count = System::Convert::ToInt32(sendPacketCountTextBox->Text);
-		for (int i = 0; i < count; i++) {
-			MultipleSendPackets();
-		}
-	}
-	else if (sendPacketIntervalRadio->Checked)
-	{
-		if (sendTimer->Enabled)
-			sendTimer->Stop();
-		else sendTimer->Start();
-	}
-}
-	private: System::Void MultipleSendPackets()
-	{
-		auto en = multiplePacketSendTextBox->Lines->GetEnumerator();
-		while (en->MoveNext())
+
+		System::Void SinglePacketReceiveButton_Click(System::Object^ sender, System::EventArgs^ e) 
 		{
-			devtale::Protocol::get()->send(marshal_as<std::string>((System::String^)en->Current));
+			try 
+			{
+			devtale::Protocol::get()->receive(marshal_as<std::string>(singlePacketReceiveTextBox->Text));
+			}
+			catch (Runtime::InteropServices::SEHException^)
+			{
+				// ignore Access Violations
+			}
 		}
-	}
-private: System::Void MultiplePacketReceiveButton_Click(System::Object^ sender, System::EventArgs^ e) {
-	if (receivePacketCountRadio->Checked) {
-		auto count = System::Convert::ToInt32(receivePacketCountTextBox->Text);
-		for (int i = 0; i < count; i++) {
-			MultipleReceivePackets();
+
+		System::Void MultiplePacketSendButton_Click(System::Object^ sender, System::EventArgs^ e) 
+		{
+			if (sendPacketCountRadio->Checked) 
+			{
+				auto count = System::Convert::ToInt32(sendPacketCountTextBox->Text);
+				for (int i = 0; i < count; i++) 
+				{
+					MultipleSendPackets();
+				}
+			}
+			else if (sendPacketIntervalRadio->Checked)
+			{
+				if (sendTimer->Enabled)
+					sendTimer->Stop();
+				else 
+					sendTimer->Start();
+			}
 		}
-	}
-	else if (receivePacketIntervalRadio->Checked)
-	{
-		if (receiveTimer->Enabled)
-			receiveTimer->Stop();
-		else receiveTimer->Start();
-	}
-}
-		private: System::Void MultipleReceivePackets()
+
+		System::Void MultipleSendPackets()
+		{
+			auto en = multiplePacketSendTextBox->Lines->GetEnumerator();
+			while (en->MoveNext())
+			{
+				devtale::Protocol::get()->send(marshal_as<std::string>((System::String^)en->Current));
+			}
+		}
+
+		System::Void MultiplePacketReceiveButton_Click(System::Object^ sender, System::EventArgs^ e) 
+		{
+			if (receivePacketCountRadio->Checked) 
+			{
+				auto count = System::Convert::ToInt32(receivePacketCountTextBox->Text);
+				for (int i = 0; i < count; i++) 
+				{
+					MultipleReceivePackets();
+				}
+			}
+			else if (receivePacketIntervalRadio->Checked)
+			{
+				if (receiveTimer->Enabled)
+					receiveTimer->Stop();
+				else 
+					receiveTimer->Start();
+			}
+		}
+
+		System::Void MultipleReceivePackets()
 		{
 			auto en = multiplePacketReceiveTextBox->Lines->GetEnumerator();
 			while (en->MoveNext())
 			{
-				try {
+				try 
+				{
 					devtale::Protocol::get()->receive(marshal_as<std::string>((System::String^)en->Current));
-				} catch (Runtime::InteropServices::SEHException^)
+				} 
+				catch (Runtime::InteropServices::SEHException^)
 				{
 					// ignore Access Violations
 				}
 			}
 		}
-private: System::Void NewSentPacketFilterButton_Click(System::Object^ sender, System::EventArgs^ e) {
-	if(newSentPacketFilterTextBox->Text == String::Empty)
-	{
-		System::Windows::Forms::MessageBox::Show("Why would anyone want to add an empty filter?");
-		return;
-	}
-	filterSentPacketList->Items->Add(newSentPacketFilterTextBox->Text);
-	newReceivedPacketFilterTextBox->Text = String::Empty;
-}
-private: System::Void NewReceivedPacketFilterButton_Click(System::Object^ sender, System::EventArgs^ e) {
-	if (newReceivedPacketFilterTextBox->Text == String::Empty)
-	{
-		System::Windows::Forms::MessageBox::Show("Why would anyone want to add an empty filter?");
-		return;
-	}
-	filterReceivedPacketList->Items->Add(newReceivedPacketFilterTextBox->Text);
-	newReceivedPacketFilterTextBox->Text = String::Empty;
-}
-private: System::Void RemoveSentPacketFilterButton_Click(System::Object^ sender, System::EventArgs^ e) {
-	if (filterSentPacketList->SelectedIndex == -1) return;
-	filterSentPacketList->Items->RemoveAt(filterSentPacketList->SelectedIndex);
-}
-private: System::Void RemoveReceivedPacketFilterButton_Click(System::Object^ sender, System::EventArgs^ e) {
-	if (filterReceivedPacketList->SelectedIndex == -1) return;
-	filterReceivedPacketList->Items->RemoveAt(filterReceivedPacketList->SelectedIndex);
-}
-private: System::Void SendTimer_Tick(System::Object^ sender, System::EventArgs^ e) {
-	MultipleSendPackets();
-}
-private: System::Void ReceiveTimer_Tick(System::Object^ sender, System::EventArgs^ e) {
-	MultipleReceivePackets();
-}
-private: System::Void SendPacketIntervalTextBox_ValueChanged(System::Object^ sender, System::EventArgs^ e) {
-	sendTimer->Interval = System::Decimal::ToInt32(sendPacketIntervalTextBox->Value);
-}
-private: System::Void ReceivePacketIntervalTextBox_ValueChanged(System::Object^ sender, System::EventArgs^ e) {
-	receiveTimer->Interval = System::Decimal::ToInt32(receivePacketIntervalTextBox->Value);
-}
-private: System::Void MainForm_FormClosing(System::Object^ sender, System::Windows::Forms::FormClosingEventArgs^ e) {
 
-	if(e->CloseReason == CloseReason::UserClosing)
-	{
-		e->Cancel = true;
-		MessageBox::Show("To close this window just exit the game.", "Error", MessageBoxButtons::OK, MessageBoxIcon::Error);
-	}
+		System::Void NewSentPacketFilterButton_Click(System::Object^ sender, System::EventArgs^ e) 
+		{
+			if(newSentPacketFilterTextBox->Text == String::Empty)
+			{
+				System::Windows::Forms::MessageBox::Show("Why would anyone want to add an empty filter?");
+				return;
+			}
+			filterSentPacketList->Items->Add(newSentPacketFilterTextBox->Text);
+			newReceivedPacketFilterTextBox->Text = String::Empty;
+		}
+
+		System::Void NewReceivedPacketFilterButton_Click(System::Object^ sender, System::EventArgs^ e) 
+		{
+			if (newReceivedPacketFilterTextBox->Text == String::Empty)
+			{
+				System::Windows::Forms::MessageBox::Show("Why would anyone want to add an empty filter?");
+				return;
+			}
+			filterReceivedPacketList->Items->Add(newReceivedPacketFilterTextBox->Text);
+			newReceivedPacketFilterTextBox->Text = String::Empty;
+		}
+
+		System::Void RemoveSentPacketFilterButton_Click(System::Object^ sender, System::EventArgs^ e) 
+		{
+			if (filterSentPacketList->SelectedIndex == -1) return;
+			filterSentPacketList->Items->RemoveAt(filterSentPacketList->SelectedIndex);
+		}
+
+		System::Void RemoveReceivedPacketFilterButton_Click(System::Object^ sender, System::EventArgs^ e) 
+		{
+			if (filterReceivedPacketList->SelectedIndex == -1) return;
+			filterReceivedPacketList->Items->RemoveAt(filterReceivedPacketList->SelectedIndex);
+		}
+
+		System::Void SendTimer_Tick(System::Object^ sender, System::EventArgs^ e) 
+		{
+			MultipleSendPackets();
+		}
+
+		System::Void ReceiveTimer_Tick(System::Object^ sender, System::EventArgs^ e) 
+		{
+			MultipleReceivePackets();
+		}
+
+		System::Void SendPacketIntervalTextBox_ValueChanged(System::Object^ sender, System::EventArgs^ e) 
+		{
+			sendTimer->Interval = System::Decimal::ToInt32(sendPacketIntervalTextBox->Value);
+		}
+
+		System::Void ReceivePacketIntervalTextBox_ValueChanged(System::Object^ sender, System::EventArgs^ e) 
+		{
+			receiveTimer->Interval = System::Decimal::ToInt32(receivePacketIntervalTextBox->Value);
+		}
+
+		System::Void MainForm_FormClosing(System::Object^ sender, System::Windows::Forms::FormClosingEventArgs^ e) 
+		{
+			if(e->CloseReason == CloseReason::UserClosing)
+			{
+	   			e->Cancel = true;
+				MessageBox::Show("To close this window just exit the game.", "Error", MessageBoxButtons::OK, MessageBoxIcon::Error);
+			}
+		}
+
+    };
 }
-};
-}
+
+#pragma warning(pop)
 
 // @formatter:on
 // ReSharper restore all

--- a/DevTale/MainForm.resx
+++ b/DevTale/MainForm.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 

--- a/DevTale/Memory.cpp
+++ b/DevTale/Memory.cpp
@@ -22,10 +22,12 @@
 #pragma optimize("", off)
 bool Memory::detour(BYTE* old_func, BYTE* new_func, const DWORD len)
 {
-	std::cout << std::hex << "Detour> detouring function at 0x" << reinterpret_cast<DWORD>(old_func) << " to 0x" <<
-		reinterpret_cast<DWORD>(new_func) << " overwriting 0x" << len << " bytes" << std::dec << std::endl;
-	std::cout << "Detour> real function region 0x" << reinterpret_cast<DWORD>(old_func) << " - 0x" << (reinterpret_cast<
-		DWORD>(old_func) + len - 1) << std::dec << std::endl;
+	std::cout << std::hex << "Detour> detouring function at 0x" << reinterpret_cast<void*>(old_func) << " to 0x" <<
+		reinterpret_cast<void*>(new_func) << " overwriting 0x" << len << " bytes" << std::dec << std::endl;
+    std::cout << "Detour> real function region 0x"
+            << reinterpret_cast<void*>(old_func) << " - 0x"
+            << (reinterpret_cast<void*>(old_func + len - 1)) << std::dec
+            << std::endl;
 	DWORD dw_real_old;
 	DWORD dw_hook_old;
 	DWORD dw_ignored;
@@ -34,10 +36,10 @@ bool Memory::detour(BYTE* old_func, BYTE* new_func, const DWORD len)
 	std::cout << "Detour> setting PAGE_READWRITE on allocated region" << std::endl;
 	VirtualProtect(new_mem4_base, total_length, PAGE_EXECUTE_READWRITE, &dw_hook_old);
 
-	std::cout << "Detour> allocated 0x" << std::hex << total_length << " bytes at " << reinterpret_cast<DWORD>(
+	std::cout << "Detour> allocated 0x" << std::hex << total_length << " bytes at " << reinterpret_cast<void*>(
 		new_mem4_base) << std::dec << std::endl;
-	std::cout << "Detour> allocated memory region 0x" << reinterpret_cast<DWORD>(new_mem4_base) << " - 0x" <<
-		reinterpret_cast<DWORD>(new_mem4_base + total_length - 1) << std::dec << std::endl;
+	std::cout << "Detour> allocated memory region 0x" << reinterpret_cast<void*>(new_mem4_base) << " - 0x" <<
+		reinterpret_cast<void*>(new_mem4_base + total_length - 1) << std::dec << std::endl;
 
 	if (new_mem4_base == nullptr)
 		return false;
@@ -56,20 +58,20 @@ bool Memory::detour(BYTE* old_func, BYTE* new_func, const DWORD len)
 	memcpy(new_mem4_base, old_func, len);
 
 	std::cout << std::hex << "Detour> setting CALL to 0x" << DWORD(new_func - old_func - 5) << " at 0x" <<
-		reinterpret_cast<DWORD>(old_func) << std::dec << std::endl;
+		reinterpret_cast<void*>(old_func) << std::dec << std::endl;
 
 	old_func[0] = 0xE8;
 	*reinterpret_cast<DWORD*>(old_func + 0x01) = DWORD(new_func - old_func - 5);
 
 	std::cout << std::hex << "Detour> setting JMP to 0x" << DWORD(new_mem4_base - (old_func + 0x5) - 5) << " at 0x" <<
-		reinterpret_cast<DWORD>(old_func + 0x06) << std::dec << std::endl;
+		reinterpret_cast<void*>(old_func + 0x06) << std::dec << std::endl;
 
 	old_func[5] = 0xE9;
 	*reinterpret_cast<DWORD*>(old_func + 0x06) = DWORD(new_mem4_base - (old_func + 0x5) - 5);
 	BYTE* new_mem4_base_end = new_mem4_base + len;
 
 	std::cout << std::hex << "Detour> setting JMP to 0x" << DWORD((old_func + 10) - new_mem4_base_end - 5) << " at 0x"
-		<< reinterpret_cast<DWORD>(new_mem4_base_end + 0x01) << std::dec << std::endl;
+		<< reinterpret_cast<void*>(new_mem4_base_end + 0x01) << std::dec << std::endl;
 
 	new_mem4_base_end[0] = 0xE9;
 	*reinterpret_cast<DWORD*>(new_mem4_base_end + 0x01) = DWORD((old_func + 10) - new_mem4_base_end - 5);
@@ -104,7 +106,7 @@ DWORD Memory::findPattern(const BYTE* b_mask, const char* sz_mask)
 
 	for (DWORD i = 0; i < dw_len; i++)
 		if (dataCompare(reinterpret_cast<unsigned char*>(dw_address + i), b_mask, sz_mask))
-			return static_cast<DWORD>(dw_address + i);
+			return dw_address + i;
 	return 0;
 }
 

--- a/DevTale/NosString.cpp
+++ b/DevTale/NosString.cpp
@@ -22,8 +22,8 @@ NosString::NosString(char* i8_string)
 
 	this->i8_string_ = static_cast<char*>(malloc(this->i32_length_ + 8 + 1));
 
-	*reinterpret_cast<unsigned long*>(this->i8_string_ + 0x00) = 1;
-	*reinterpret_cast<unsigned long*>(this->i8_string_ + 0x04) = this->i32_length_;
+	*reinterpret_cast<size_t*>(this->i8_string_ + 0x00) = 1;
+	*reinterpret_cast<size_t*>(this->i8_string_ + 0x04) = this->i32_length_;
 
 	memcpy(this->i8_string_ + 0x08, i8_string, this->i32_length_);
 
@@ -35,7 +35,7 @@ char* NosString::get() const
 	return this->i8_string_ + 0x08;
 }
 
-unsigned long NosString::length() const
+size_t NosString::length() const
 {
 	return this->i32_length_;
 }

--- a/DevTale/NosString.h
+++ b/DevTale/NosString.h
@@ -21,12 +21,12 @@ class NosString
 {
 private:
 	char* i8_string_;
-	unsigned long i32_length_;
+	size_t i32_length_;
 
 public:
 	explicit NosString(char* i8_string);
 
 	char* get() const;
 
-	unsigned long length() const;
+	size_t length() const;
 };

--- a/DevTale/devtale.vcxproj
+++ b/DevTale/devtale.vcxproj
@@ -90,9 +90,10 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <AdditionalDependencies />
@@ -101,9 +102,10 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <AdditionalDependencies />
@@ -111,8 +113,9 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <AdditionalDependencies />
@@ -121,8 +124,9 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <AdditionalDependencies />

--- a/DevTale/main.cpp
+++ b/DevTale/main.cpp
@@ -15,10 +15,13 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #define WIN32_LEAN_AND_MEAN
+#include <thread>
 #include "windows.h"
 #include "MainForm.h"
 #include "Protocol.h"
 #include "PacketHandler.h"
+
+#define UNUSED(x) (void*)(x)
 
 void WINAPI DllThread()
 {
@@ -40,22 +43,20 @@ void CreateDebugWindow()
 	std::cout.clear();
 }
 
-void WINAPI Setup()
-{
-	devtale::Protocol::get();
-	CreateThread(nullptr, 0, reinterpret_cast<LPTHREAD_START_ROUTINE>(DllThread), nullptr, 0, nullptr);
-}
-
 bool WINAPI DllMain(_In_ HINSTANCE instance, _In_ DWORD call_reason, _In_ LPVOID reserved)
 {
+    UNUSED(instance);
+    UNUSED(reserved);
+
 	switch (call_reason)
 	{
-	case DLL_PROCESS_ATTACH:
+    case DLL_PROCESS_ATTACH: {
 #ifdef _DEBUG
-		CreateDebugWindow();
+        CreateDebugWindow();
 #endif
-		CreateThread(nullptr, 0, reinterpret_cast<LPTHREAD_START_ROUTINE>(Setup), nullptr, 0, nullptr);
-		break;
+        std::thread dll(DllThread);
+        dll.detach();
+	} break;
 	case DLL_THREAD_ATTACH:
 	case DLL_THREAD_DETACH:
 	case DLL_PROCESS_DETACH:

--- a/devtale.sln
+++ b/devtale.sln
@@ -3,22 +3,16 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29001.49
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "devtale", "DevTale\devtale.vcxproj", "{3800A4A3-C59F-47AE-8E13-E4527DCA907D}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DevTale", "DevTale\devtale.vcxproj", "{3800A4A3-C59F-47AE-8E13-E4527DCA907D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{3800A4A3-C59F-47AE-8E13-E4527DCA907D}.Debug|x64.ActiveCfg = Debug|x64
-		{3800A4A3-C59F-47AE-8E13-E4527DCA907D}.Debug|x64.Build.0 = Debug|x64
 		{3800A4A3-C59F-47AE-8E13-E4527DCA907D}.Debug|x86.ActiveCfg = Debug|Win32
 		{3800A4A3-C59F-47AE-8E13-E4527DCA907D}.Debug|x86.Build.0 = Debug|Win32
-		{3800A4A3-C59F-47AE-8E13-E4527DCA907D}.Release|x64.ActiveCfg = Release|x64
-		{3800A4A3-C59F-47AE-8E13-E4527DCA907D}.Release|x64.Build.0 = Release|x64
 		{3800A4A3-C59F-47AE-8E13-E4527DCA907D}.Release|x86.ActiveCfg = Release|Win32
 		{3800A4A3-C59F-47AE-8E13-E4527DCA907D}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection


### PR DESCRIPTION
main.cpp - lekko wyczyszczone, std::thread zamiast wątków winapi
poziom ostrzeżeń dla projektu podniesiony z W3 do W4
wszystkie ostrzeżenia traktowane jako błędy
printowanie wskaźników w konsoli - zmieniłem rzutowanie z DWORD do void*
w MainForm.h większość funkcji nie używa wszystkich parametrów co generuje ostrzeżenie C4100 - wyłączyłem je w tym pliku
usunąłem całkiem buildy x64 bo biorąc pod uwagę działanie programu adresy działały bardzo różnie

zmieniony kod działa poprawnie (testowany)
forma poprawnie pokazuje się w designerze po zmianach - w nawiązaniach do komentarza (vs 19)